### PR TITLE
Update project to work properly again

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,18 @@ task buildTexFile(type: TexCompile) {
 
 (You may need to import [`TexCompile`](src/main/kotlin/dev/reimer/tex/gradle/plugin/task/TexCompile.kt))
 
-This configuration autodetects if a `sample.bib` is present, 
+This configuration autodetects if a `sample.bib` is present,
 and builds the resulting `sample.pdf`.
 Compiled PDFs are stored in the `out/` directory under the project root.
-Setting the `destinationDir` property overwrites 
+Setting the `destinationDir` property overwrites
 the default output directory.
 
 You can register as many tex compile tasks as you like.
-Alternatively, reference a directory, file tree 
-or [more](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#files-java.lang.Object...-), 
+Alternatively, reference a directory, file tree
+or [more](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#files-java.lang.Object...-),
 using the `source()` task configuration.
 
-And don't worry about a messy `out/` directory, 
+And don't worry about a messy `out/` directory,
 as the folder structure will be preserved.
 
 ### Options
@@ -154,12 +154,13 @@ Those are TeX projects, used for integration tests.
 
 ## Thanks
 
-I am grateful to @DanySK for his work on the forked library, 
+I am grateful to @DanySK for his work on the forked library,
 which was licensed under the [Apache License 2.0](https://github.com/DanySK/gradle-latex/blob/master/LICENSE).
 
 ## Status α
 
 ⚠️ _Warning:_ This project is in an experimental alpha stage:
+
 - The API may be changed at any time without further notice.
 - Development still happens on `master`.
 - Pull Requests are highly appreciated!

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,8 +67,8 @@ publishing {
     publications {
         create<MavenPublication>("maven") {
             from(components["java"])
-            artifact(sourcesJar.get())
-            artifact(javadocJar.get())
+            //artifact(sourcesJar.get())
+            //artifact(javadocJar.get())
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,13 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import org.jetbrains.dokka.gradle.DokkaTask
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "1.9.22"
     `java-gradle-plugin`
-    id("com.gradle.plugin-publish") version "1.2.1"
-    id("org.jetbrains.dokka") version "0.10.0"
+    id("com.gradle.plugin-publish") version "1.2.2"
+    id("org.jetbrains.dokka") version "1.9.20"
     `maven-publish`
-    id("com.palantir.git-version") version "3.0.0"
+    id("com.palantir.git-version") version "3.1.0"
 }
 
 val gitVersion: groovy.lang.Closure<String> by extra
@@ -23,7 +21,7 @@ repositories {
 dependencies {
     implementation(kotlin("stdlib"))
     implementation(gradleKotlinDsl())
-    testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.0")
 }
 
 lateinit var javadocJar: TaskProvider<Jar>
@@ -50,16 +48,11 @@ tasks {
         }
     }
 
-    // Generate Kotlin/Java documentation from sources.
-    dokka {
-        outputFormat = "html"
-    }
-
     // JAR containing Kotlin/Java documentation.
     javadocJar = register<Jar>("javadocJar") {
         group = JavaBasePlugin.DOCUMENTATION_GROUP
-        dependsOn(dokka)
-        from(dokka)
+        dependsOn(dokkaHtml)
+        from(dokkaHtml)
         archiveClassifier.set("javadoc")
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,8 +67,8 @@ publishing {
     publications {
         create<MavenPublication>("maven") {
             from(components["java"])
-            //artifact(sourcesJar.get())
-            //artifact(javadocJar.get())
+            artifact(sourcesJar.get())
+            artifact(javadocJar.get())
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/TexPlugin.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/TexPlugin.kt
@@ -13,6 +13,7 @@ class TexPlugin : Plugin<Project> {
     companion object {
         const val TASK_GROUP = "tex"
         const val EXTENSION_NAME = "tex"
+
         @Suppress("UnstableApiUsage")
         const val ASSEMBLE_TASK_NAME = LifecycleBasePlugin.ASSEMBLE_TASK_NAME
         const val ASSEMBLE_TEX_TASK_NAME = ASSEMBLE_TASK_NAME + "Tex"

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/Utils.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/Utils.kt
@@ -1,5 +1,6 @@
 package dev.reimer.tex.gradle.plugin
 
+import dev.reimer.tex.gradle.plugin.internal.FilteredFileTree
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.*
@@ -55,4 +56,4 @@ operator fun File.contains(other: File): Boolean {
  * @param filter The criteria to use to select the contents of the filtered collection.
  * @return The filtered collection.
  */
-fun FileTree.filterAsTree(filter: (FileTreeElement) -> Boolean): FileTree = this.filter(closureOf<FileTreeElement> { filter(this) }).asFileTree
+fun FileTree.filterAsTree(filter: (FileTreeElement) -> Boolean): FileTree = FilteredFileTree(this, filter)

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/Utils.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/Utils.kt
@@ -7,7 +7,6 @@ import org.gradle.api.file.*
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.property
-import org.gradle.kotlin.dsl.closureOf
 import java.io.File
 
 inline fun <reified T : Any> Project.property(): Property<T> = objects.property()

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Biber.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Biber.kt
@@ -1,9 +1,9 @@
 package dev.reimer.tex.gradle.plugin.compiler.bibliography
 
 import dev.reimer.tex.gradle.plugin.internal.FileExtensions
+import groovy.namespace.QName
 import groovy.util.Node
-import groovy.util.XmlParser
-import groovy.xml.QName
+import groovy.xml.XmlParser
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.InputFile

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Biber.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Biber.kt
@@ -7,6 +7,7 @@ import groovy.xml.XmlParser
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
 import java.io.File
 
 open class Biber : DefaultBibliographyCompiler() {
@@ -67,7 +68,7 @@ open class Biber : DefaultBibliographyCompiler() {
 
     private val bcfFileName: Provider<String> = jobName.map { "$it.${FileExtensions.BCF}" }
 
-    @get:InputDirectory
+    @get:InputFile
     protected val bcfFile: Provider<RegularFile> =
         project.layout.file(buildDir.map { it.asFile.resolve(bcfFileName.get()) })
 

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Biber.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Biber.kt
@@ -6,7 +6,7 @@ import groovy.util.Node
 import groovy.xml.XmlParser
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputDirectory
 import java.io.File
 
 open class Biber : DefaultBibliographyCompiler() {
@@ -67,7 +67,7 @@ open class Biber : DefaultBibliographyCompiler() {
 
     private val bcfFileName: Provider<String> = jobName.map { "$it.${FileExtensions.BCF}" }
 
-    @get:InputFile
+    @get:InputDirectory
     protected val bcfFile: Provider<RegularFile> =
         project.layout.file(buildDir.map { it.asFile.resolve(bcfFileName.get()) })
 

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Biber.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Biber.kt
@@ -6,7 +6,6 @@ import groovy.util.Node
 import groovy.xml.XmlParser
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import java.io.File
 

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/BibliographyCompiler.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/BibliographyCompiler.kt
@@ -6,6 +6,7 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputFile
 
 /**
@@ -18,10 +19,10 @@ interface BibliographyCompiler : Task {
     @get:Input
     val jobName: Property<String>
 
-    @get:Input
+    @get:InputDirectory
     val buildDir: DirectoryProperty
 
-    @get:Input
+    @get:InputDirectory
     val sourceDir: DirectoryProperty
 
     @get:Input

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Bibtex.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Bibtex.kt
@@ -30,6 +30,7 @@ open class Bibtex : DefaultBibliographyCompiler() {
                             }
                             listOf(File(file))
                         }
+
                         bibStyle != null -> {
                             val file = bibStyle.groupValues[1].let { name ->
                                 when {
@@ -39,10 +40,12 @@ open class Bibtex : DefaultBibliographyCompiler() {
                             }
                             listOf(File(file))
                         }
+
                         input != null -> {
                             val file = input.groupValues[1]
                             parseResources(buildDir, buildDir.resolve(file))
                         }
+
                         else -> emptyList()
                     }
                 }.toList()

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Bibtex.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/compiler/bibliography/Bibtex.kt
@@ -30,7 +30,6 @@ open class Bibtex : DefaultBibliographyCompiler() {
                             }
                             listOf(File(file))
                         }
-
                         bibStyle != null -> {
                             val file = bibStyle.groupValues[1].let { name ->
                                 when {
@@ -40,12 +39,10 @@ open class Bibtex : DefaultBibliographyCompiler() {
                             }
                             listOf(File(file))
                         }
-
                         input != null -> {
                             val file = input.groupValues[1]
                             parseResources(buildDir, buildDir.resolve(file))
                         }
-
                         else -> emptyList()
                     }
                 }.toList()

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/FilteredFileTree.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/FilteredFileTree.kt
@@ -6,7 +6,6 @@ import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
 import org.gradle.api.internal.file.AbstractFileCollection
 import org.gradle.api.internal.file.AbstractFileTree
-import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.tasks.util.PatternFilterable

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/FilteredFileTree.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/FilteredFileTree.kt
@@ -1,0 +1,53 @@
+package dev.reimer.tex.gradle.plugin.internal
+
+import org.gradle.api.file.FileTree
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.file.FileVisitDetails
+import org.gradle.api.file.FileVisitor
+import org.gradle.api.internal.file.AbstractFileCollection
+import org.gradle.api.internal.file.AbstractFileTree
+import org.gradle.api.internal.file.FileCollectionStructureVisitor
+import org.gradle.api.internal.file.FileTreeInternal
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext
+import org.gradle.api.tasks.util.PatternFilterable
+import java.util.function.Consumer
+
+/**
+ * See [AbstractFileTree.FilteredFileTreeImpl].
+ */
+class FilteredFileTree(
+    private val fileTree: FileTree,
+    private val spec: (FileTreeElement) -> Boolean
+) : AbstractFileTree() {
+
+    private val abstractFileTree = fileTree as? AbstractFileCollection
+
+    override fun getDisplayName() = abstractFileTree?.displayName ?: ""
+    override fun matching(patterns: PatternFilterable): FileTreeInternal {
+        TODO("Not yet implemented")
+    }
+
+    override fun visitDependencies(context: TaskDependencyResolveContext) = context.add(fileTree)
+
+    override fun visit(visitor: FileVisitor): FileTree {
+        fileTree.visit(object : FileVisitor {
+            override fun visitDir(dirDetails: FileVisitDetails) {
+                if (spec(dirDetails)) visitor.visitDir(dirDetails)
+            }
+
+            override fun visitFile(fileDetails: FileVisitDetails) {
+                if (spec(fileDetails)) visitor.visitFile(fileDetails)
+            }
+        })
+        return this
+    }
+
+    override fun visitContentsAsFileTrees(visitor: Consumer<FileTreeInternal>) {
+        TODO("Not yet implemented")
+    }
+
+//    override fun visitStructure(visitor: FileCollectionStructureVisitor) {
+//        abstractFileTree?.visitStructure(visitor)
+//    }
+
+}

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/TexCompileFileFilter.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/TexCompileFileFilter.kt
@@ -7,5 +7,5 @@ import java.io.FileFilter
 
 internal class TexCompileFileFilter(private val project: Project) : FileFilter {
     override fun accept(pathname: File) =
-        pathname.extension == FileExtensions.TEX && pathname.isFile && pathname !in project.buildDir
+        pathname.extension == FileExtensions.TEX && pathname.isFile && pathname !in project.layout.buildDirectory.asFileTree
 }

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/TexCompileFileFilter.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/TexCompileFileFilter.kt
@@ -1,6 +1,5 @@
 package dev.reimer.tex.gradle.plugin.internal
 
-import dev.reimer.tex.gradle.plugin.contains
 import org.gradle.api.Project
 import java.io.File
 import java.io.FileFilter

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/TexResourcesFileFilter.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/TexResourcesFileFilter.kt
@@ -6,5 +6,5 @@ import java.io.File
 import java.io.FileFilter
 
 internal class TexResourcesFileFilter(private val project: Project) : FileFilter {
-    override fun accept(pathname: File) = pathname.isFile && pathname !in project.buildDir
+    override fun accept(pathname: File) = pathname.isFile && pathname !in project.layout.buildDirectory.asFileTree
 }

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/TexResourcesFileFilter.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/internal/TexResourcesFileFilter.kt
@@ -1,6 +1,5 @@
 package dev.reimer.tex.gradle.plugin.internal
 
-import dev.reimer.tex.gradle.plugin.contains
 import org.gradle.api.Project
 import java.io.File
 import java.io.FileFilter

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/task/TexCompile.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/task/TexCompile.kt
@@ -5,9 +5,11 @@ import dev.reimer.tex.gradle.plugin.compiler.CompilerFactory
 import dev.reimer.tex.gradle.plugin.internal.TexCompileFileFilter
 import org.gradle.api.file.RelativePath
 import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Optional
 import org.gradle.kotlin.dsl.register
 import java.io.File
 import java.io.FileFilter
+import java.util.*
 
 /**
  * Compile a TeX project.
@@ -43,13 +45,13 @@ open class TexCompile : FilteredSourceTask(), TexScope {
      */
     @get:Internal
     val buildDir = project.directoryProperty {
-        project.buildDir.resolve(TexPlugin.EXTENSION_NAME).resolve(name)
+        project.layout.buildDirectory.get().asFile.resolve(TexPlugin.EXTENSION_NAME).resolve(name)
     }
 
     init {
         val generateResources = let { tex ->
             project.tasks.register<TexResources>(
-                "generateResourcesFor${name.capitalize()}"
+                "generateResourcesFor${name.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }}"
             ) {
                 imageConverter.set(tex.imageConverter)
                 destinationDir.set(tex.buildDir)

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/task/TexCompile.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/task/TexCompile.kt
@@ -55,7 +55,7 @@ open class TexCompile : FilteredSourceTask(), TexScope {
             ) {
                 imageConverter.set(tex.imageConverter)
                 destinationDir.set(tex.buildDir)
-                setSource(tex.source)
+                source = tex.source
             }
         }
 

--- a/src/main/kotlin/dev/reimer/tex/gradle/plugin/task/TexCompile.kt
+++ b/src/main/kotlin/dev/reimer/tex/gradle/plugin/task/TexCompile.kt
@@ -51,7 +51,7 @@ open class TexCompile : FilteredSourceTask(), TexScope {
     init {
         val generateResources = let { tex ->
             project.tasks.register<TexResources>(
-                "generateResourcesFor${name.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }}"
+                "generateResourcesFor${name.replaceFirstChar(Char::titlecase)}"
             ) {
                 imageConverter.set(tex.imageConverter)
                 destinationDir.set(tex.buildDir)

--- a/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
+++ b/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
@@ -28,7 +28,7 @@ class TexTests : StringSpec({
             // Copy sample dir.
             test.directory.copyRecursively(root)
 
-            // Create a build file.
+            // Create build file.
             newFile("build.gradle.kts").writeText(test.buildFile)
 
             log.debug("Test has been copied into $root and is ready to get executed")

--- a/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
+++ b/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory
 class TexTests : StringSpec({
 
     val configs = setOf(
-        //ElsevierTest,
+        ElsevierTest,
         LatexGuideTest,
         SimpleLatexTest,
         SimpleLatexIncludeTest,

--- a/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
+++ b/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
@@ -22,7 +22,7 @@ class TexTests : StringSpec({
         SimpleLatexBiberIncludeTest
     )
     configs.forEach { test ->
-        log.debug("Test to be executed: {} from {}", test, test.directory)
+        log.debug("Test to be executed: $test from ${test.directory}")
 
         temporaryFolder {
             // Copy sample dir.

--- a/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
+++ b/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
@@ -31,7 +31,7 @@ class TexTests : StringSpec({
             // Create a build file.
             newFile("build.gradle.kts").writeText(test.buildFile)
 
-            log.debug("Test has been copied into {} and is ready to get executed", root)
+            log.debug("Test has been copied into $root and is ready to get executed")
 
             test.description {
                 // Delete expected files before build.

--- a/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
+++ b/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
@@ -61,7 +61,7 @@ class TexTests : StringSpec({
                 }
             }
         }
-        }
+    }
 }) {
     companion object {
         val log: Logger = LoggerFactory.getLogger(TexTests::class.java)

--- a/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
+++ b/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory
 class TexTests : StringSpec({
 
     val configs = setOf(
-        ElsevierTest,
+        //ElsevierTest,
         LatexGuideTest,
         SimpleLatexTest,
         SimpleLatexIncludeTest,

--- a/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
+++ b/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
@@ -1,9 +1,9 @@
 package dev.reimer.tex.gradle.plugin
 
-import io.kotlintest.matchers.file.shouldBeAFile
-import io.kotlintest.matchers.file.shouldExist
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.StringSpec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.file.shouldBeAFile
+import io.kotest.matchers.file.shouldExist
+import io.kotest.matchers.shouldBe
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.slf4j.Logger

--- a/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
+++ b/src/test/kotlin/dev/reimer/tex/gradle/plugin/TexTests.kt
@@ -22,16 +22,16 @@ class TexTests : StringSpec({
         SimpleLatexBiberIncludeTest
     )
     configs.forEach { test ->
-        log.debug("Test to be executed: $test from ${test.directory}")
+        log.debug("Test to be executed: {} from {}", test, test.directory)
 
         temporaryFolder {
             // Copy sample dir.
             test.directory.copyRecursively(root)
 
-            // Create build file.
+            // Create a build file.
             newFile("build.gradle.kts").writeText(test.buildFile)
 
-            log.debug("Test has been copied into $root and is ready to get executed")
+            log.debug("Test has been copied into {} and is ready to get executed", root)
 
             test.description {
                 // Delete expected files before build.


### PR DESCRIPTION
Hey,
I fixed the plugin for me at least. I am a bit unsure if it is what you intended with it. The reason is that I undid the changes you did to the `Utils.kt` file, where you removed your implementation of the `FilteredFileTree`. Your implementation you did in 1f56de90079aeaf08ec5845f217ee558bae58b48 to `Utils.kt` caused a ClassCastException for me, and I couldn't figure out what your idea with this change was. I suppose that there were missing a few changes and weren't committed. If so, I am happy to merge them and update this pull request.

I also updated the gradle version to the latest Gradle release 8.10 and also fix some deprecation warnings and updated dependencies.

For me all tests pass except for the one for the `ElsevierTest`. But I can not compile the tex file with my current latex installation, so I guess I am missing some packages. Apart from that it works fine. I could also use the plugin a seperate project successfully.

